### PR TITLE
Logging errors from ChartMuseum, added support for organizations in CM

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,15 @@ $ curl -L --data-binary "@<packge-name>" <chartmuseum-url>/api/charts
    
 In the browser, navigate to localhost and view your charts
 
+### Using with ChartMuseum with Multitenancy enabled
+
+To use ChartMuseumUI on a ChartMuseum with Multitenancy support enabled, add the following environment variable to ChartMuseumUI
+
+```
+CHART_MUSESUM_API_GET_CHARTS: "/api/org1/charts"
+```
+
+Currently only one organization is allowed per ChartMuseumUI.
 
 ## Built With
 

--- a/models/error.go
+++ b/models/error.go
@@ -1,0 +1,15 @@
+package models
+
+import (
+	"encoding/json"
+)
+
+type Error struct {
+	Message        string       `json:"error"`
+}
+
+func NewError(data []byte) (Error, error) {
+	var e Error
+	err := json.Unmarshal(data, &e)
+	return e, err
+}


### PR DESCRIPTION
- Added Error model to deserialize json errors from ChartMuseum into.
- Changed panic logging to use message from error model
- Added option to use ChartMuseum/ui with ChartMuseums that use organizations

Error logging looks like this:
```
ui_1           | 2019/02/11 13:14:48.817  Error received from ChartMuseum application: chart not found
ui_1           | %!(EXTRA *json.UnmarshalTypeError=json: cannot unmarshal string into Go value of type []models.Chart)
```
Where `chart not found` is the actual error from ChartMuseum.