### PR TITLE
Simple basic auth implementation

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -39,6 +39,11 @@
 			"Rev": "053a075344c118a5cc41981b29ef612bb53d20ca"
 		},
 		{
+			"ImportPath": "github.com/astaxie/beego/plugins/auth",
+			"Comment": "v1.10.1",
+			"Rev": "053a075344c118a5cc41981b29ef612bb53d20ca"
+		},
+		{
 			"ImportPath": "github.com/astaxie/beego/session",
 			"Comment": "v1.10.1",
 			"Rev": "053a075344c118a5cc41981b29ef612bb53d20ca"

--- a/README.md
+++ b/README.md
@@ -95,6 +95,15 @@ CHART_MUSESUM_API_GET_CHARTS: "/api/org1/charts"
 
 Currently only one organization is allowed per ChartMuseumUI.
 
+
+### Adding authentication to ChartMuseumUI 
+
+To add a simple basic auth to ChartMuseumUI, you can add the following configuration
+
+```
+BASIC_AUTH_USERS: '[{"username":"admin", "password":"password"}, {"username":"user", "password":"s3cr3t"}]'
+```
+
 ## Built With
 
 * [beego](https://beego.me/) - The web framework used

--- a/models/user.go
+++ b/models/user.go
@@ -1,0 +1,16 @@
+package models
+
+import (
+	"encoding/json"
+)
+
+type User struct {
+	Username        string       `json:"username"`
+	Password        string       `json:"password"`
+}
+
+func NewUsers(data []byte) ([]User, error) {
+	var u []User
+	err := json.Unmarshal(data, &u)
+	return u, err
+}

--- a/routers/router.go
+++ b/routers/router.go
@@ -12,14 +12,7 @@ import (
 )
 
 func init() {
-	l := logs.GetLogger()
-
-	userJson := os.Getenv("BASIC_AUTH_USERS")
-	if len(userJson) != 0 {
-		l.Println("Using basic auth")
-		authPlugin := auth.NewBasicAuthenticator(services.SecretAuth, "Authorization Required")
-		beego.InsertFilter("*", beego.BeforeRouter, authPlugin, true)
-	}
+	setupAuthentication()
 
 	beego.Router("/", &controllers.MainController{})
 	//beego.Router("/login", &controllers.LogInController{})
@@ -28,4 +21,15 @@ func init() {
 	beego.Router("/home", &controllers.MainController{})
 	beego.Router("/home/chart/?:name", &controllers.ChartController{})
 	beego.Router("/chart/?:name", &controllers.ChartController{})
+}
+
+func setupAuthentication() {
+	l := logs.GetLogger()
+
+	userJson := os.Getenv("BASIC_AUTH_USERS")
+	if len(userJson) != 0 {
+		l.Println("Using basic auth")
+		authPlugin := auth.NewBasicAuthenticator(services.SecretAuth, "Authorization Required")
+		beego.InsertFilter("*", beego.BeforeRouter, authPlugin, true)
+	}
 }

--- a/routers/router.go
+++ b/routers/router.go
@@ -1,12 +1,26 @@
 package routers
 
 import (
+	"os"
+
+	"github.com/chartmuseum/ui/services"
 	"github.com/chartmuseum/ui/controllers"
 
 	"github.com/astaxie/beego"
+	"github.com/astaxie/beego/plugins/auth"
+	"github.com/astaxie/beego/logs"
 )
 
 func init() {
+	l := logs.GetLogger()
+
+	userJson := os.Getenv("BASIC_AUTH_USERS")
+	if len(userJson) != 0 {
+		l.Println("Using basic auth")
+		authPlugin := auth.NewBasicAuthenticator(services.SecretAuth, "Authorization Required")
+		beego.InsertFilter("*", beego.BeforeRouter, authPlugin, true)
+	}
+
 	beego.Router("/", &controllers.MainController{})
 	//beego.Router("/login", &controllers.LogInController{})
 	beego.Router("/delete", &controllers.DeleteChartController{})

--- a/services/login.go
+++ b/services/login.go
@@ -1,0 +1,44 @@
+package services
+
+import (
+	"os"
+	"errors"
+
+	"github.com/chartmuseum/ui/models"
+
+	"github.com/astaxie/beego/logs"
+)
+
+
+func SecretAuth(username, password string) bool {
+	l := logs.GetLogger()
+
+	users, err := getUsersFromEnv()
+	if err != nil {
+		l.Panic(err)
+	}
+
+	for _, user := range users {
+		if username == user.Username && password == user.Password {
+			return true
+		}
+	}
+    return false
+}
+
+func getUsersFromEnv() ([]models.User, error) {
+
+	l := logs.GetLogger()
+
+	userJson := os.Getenv("BASIC_AUTH_USERS")
+	if len(userJson) == 0 {
+		return nil, errors.New("No users defined. Create environment var BASIC_AUTH_USERS")
+	}
+	
+	users, err := models.NewUsers([]byte(userJson))
+	if err != nil {
+		l.Panic(err)
+	}
+
+	return users, nil
+}

--- a/vendor/github.com/astaxie/beego/plugins/auth/basic.go
+++ b/vendor/github.com/astaxie/beego/plugins/auth/basic.go
@@ -1,0 +1,107 @@
+// Copyright 2014 beego Author. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package auth provides handlers to enable basic auth support.
+// Simple Usage:
+//	import(
+//		"github.com/astaxie/beego"
+//		"github.com/astaxie/beego/plugins/auth"
+//	)
+//
+//	func main(){
+//		// authenticate every request
+//		beego.InsertFilter("*", beego.BeforeRouter,auth.Basic("username","secretpassword"))
+//		beego.Run()
+//	}
+//
+//
+// Advanced Usage:
+//
+//	func SecretAuth(username, password string) bool {
+//		return username == "astaxie" && password == "helloBeego"
+//	}
+//	authPlugin := auth.NewBasicAuthenticator(SecretAuth, "Authorization Required")
+//	beego.InsertFilter("*", beego.BeforeRouter,authPlugin)
+package auth
+
+import (
+	"encoding/base64"
+	"net/http"
+	"strings"
+
+	"github.com/astaxie/beego"
+	"github.com/astaxie/beego/context"
+)
+
+var defaultRealm = "Authorization Required"
+
+// Basic is the http basic auth
+func Basic(username string, password string) beego.FilterFunc {
+	secrets := func(user, pass string) bool {
+		return user == username && pass == password
+	}
+	return NewBasicAuthenticator(secrets, defaultRealm)
+}
+
+// NewBasicAuthenticator return the BasicAuth
+func NewBasicAuthenticator(secrets SecretProvider, Realm string) beego.FilterFunc {
+	return func(ctx *context.Context) {
+		a := &BasicAuth{Secrets: secrets, Realm: Realm}
+		if username := a.CheckAuth(ctx.Request); username == "" {
+			a.RequireAuth(ctx.ResponseWriter, ctx.Request)
+		}
+	}
+}
+
+// SecretProvider is the SecretProvider function
+type SecretProvider func(user, pass string) bool
+
+// BasicAuth store the SecretProvider and Realm
+type BasicAuth struct {
+	Secrets SecretProvider
+	Realm   string
+}
+
+// CheckAuth Checks the username/password combination from the request. Returns
+// either an empty string (authentication failed) or the name of the
+// authenticated user.
+// Supports MD5 and SHA1 password entries
+func (a *BasicAuth) CheckAuth(r *http.Request) string {
+	s := strings.SplitN(r.Header.Get("Authorization"), " ", 2)
+	if len(s) != 2 || s[0] != "Basic" {
+		return ""
+	}
+
+	b, err := base64.StdEncoding.DecodeString(s[1])
+	if err != nil {
+		return ""
+	}
+	pair := strings.SplitN(string(b), ":", 2)
+	if len(pair) != 2 {
+		return ""
+	}
+
+	if a.Secrets(pair[0], pair[1]) {
+		return pair[0]
+	}
+	return ""
+}
+
+// RequireAuth http.Handler for BasicAuth which initiates the authentication process
+// (or requires reauthentication).
+func (a *BasicAuth) RequireAuth(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("WWW-Authenticate", `Basic realm="`+a.Realm+`"`)
+	w.WriteHeader(401)
+	w.Write([]byte("401 Unauthorized\n"))
+}


### PR DESCRIPTION
Simple implementation of Basic Auth for ChartMuseumUI.

If the environment variable (`BASIC_AUTH_USERS`) with the users is set (as a `json array`), the browser will ask for authentication.

I went for a simple and easy to use implementation without a dedicated database to get new users flying fast.
This also matches the current experience for ChartMuseum authentication.

Any comments @jdolitsky @idobry ?