### PR TITLE
Fix viewport for main gallery CSS

### DIFF
--- a/views/head.tpl
+++ b/views/head.tpl
@@ -138,8 +138,8 @@ footer {
 }
 
 .gallery{
-  width: 40vw;
-  margin: 0 auto;
+  width: 70vw;
+  margin: auto;
   display: grid;
   grid-template-columns: repeat(4, minmax(15rem, 1fr));
   grid-row-gap: 20px;


### PR DESCRIPTION
Fixes https://github.com/chartmuseum/ui/issues/22, a small issue where ChartMuseumUI is not displaying correctly for Firefox or Chrome. Setting the gallery margin to full-auto and increasing the viewport space used improves this.

Before:

<img width="1680" alt="before" src="https://user-images.githubusercontent.com/19230462/55035915-be90b780-4fde-11e9-90d4-d3085609e2ec.png">

After:

<img width="1680" alt="after" src="https://user-images.githubusercontent.com/19230462/55035967-df590d00-4fde-11e9-9153-c42ec4c4de76.png">
